### PR TITLE
Add event scraping utilities with tests

### DIFF
--- a/events/scraper.py
+++ b/events/scraper.py
@@ -1,0 +1,59 @@
+import requests
+from bs4 import BeautifulSoup
+from ics import Calendar
+from urllib.parse import quote_plus
+
+
+def find_calendar_urls(query, max_results=5):
+    """Search DuckDuckGo for calendar URLs in ICS format."""
+    search_url = (
+        f"https://duckduckgo.com/html/?q="
+        f"{quote_plus(query + ' events calendar ics')}"
+    )
+    resp = requests.get(search_url, headers={"User-Agent": "Mozilla/5.0"})
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    urls = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.lower().endswith(".ics"):
+            urls.append(href)
+            if len(urls) >= max_results:
+                break
+    return urls
+
+
+def parse_ics(content):
+    """Parse ICS calendar content and return list of event dictionaries."""
+    calendar = Calendar(content)
+    events = []
+    for ev in calendar.events:
+        events.append({
+            "uid": ev.uid,
+            "title": ev.name,
+            "description": ev.description,
+            "location": ev.location,
+            "start_time": ev.begin.datetime,
+            "end_time": ev.end.datetime if ev.end else None,
+            "url": str(ev.url) if ev.url else None,
+        })
+    return events
+
+
+def fetch_ics_events(url):
+    """Download an ICS file from the given URL and parse events."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return parse_ics(resp.text)
+
+
+
+def scrape_events_for_query(query):
+    """Find calendar URLs for the query and return parsed events."""
+    events = []
+    for url in find_calendar_urls(query):
+        try:
+            events.extend(fetch_ics_events(url))
+        except requests.RequestException:
+            continue
+    return events

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 Django==5.0.1
+requests
+beautifulsoup4
+ics
+pytest
+responses

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import re
+import responses
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from events.scraper import find_calendar_urls, parse_ics
+
+
+def test_parse_ics():
+    content = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//example//Test//EN
+BEGIN:VEVENT
+UID:test1@example.com
+SUMMARY:Sample Event
+DESCRIPTION:Testing
+LOCATION:Boston
+DTSTART:20240101T100000Z
+DTEND:20240101T110000Z
+URL:https://example.com/event
+END:VEVENT
+END:VCALENDAR
+"""
+    events = parse_ics(content)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["title"] == "Sample Event"
+    assert ev["location"] == "Boston"
+    assert ev["url"] == "https://example.com/event"
+
+
+@responses.activate
+def test_find_calendar_urls():
+    html = "<html><body><a href='https://example.com/events.ics'>cal</a></body></html>"
+    pattern = re.compile(r"https://duckduckgo.com/html/.*")
+    responses.get(pattern, body=html)
+    urls = find_calendar_urls("boston college")
+    assert urls == ["https://example.com/events.ics"]


### PR DESCRIPTION
## Summary
- implement event scraping helpers that search DuckDuckGo for `.ics` calendars
- parse calendars using the ics library
- expose helpers to download events for a query
- add tests covering calendar parsing and URL extraction
- update project requirements for scraping and testing packages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ff119fa483339fa9153aba906a60