### PR TITLE
Require auth and date filtering for events API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,12 +1,13 @@
 from typing import List
+from datetime import date, datetime, time
 
 from ninja import ModelSchema, Router
-from ninja_jwt.authentication import JWTAuth
+from django.utils import timezone
 
 from events.models import Event
 
 
-router = Router(auth=JWTAuth())
+router = Router()
 
 
 class EventSchema(ModelSchema):
@@ -29,6 +30,21 @@ def ping(request):
 
 
 @router.get("/events", response=List[EventSchema])
-def list_events(request):
-    return Event.objects.all().order_by("start_time")
+def list_events(request, start: date | None = None, end: date | None = None):
+    qs = Event.objects.all().order_by("start_time")
+
+    if start or end:
+        if start:
+            start_dt = timezone.make_aware(datetime.combine(start, time.min))
+        else:
+            start_dt = timezone.now()
+        qs = qs.filter(start_time__gte=start_dt)
+
+        if end:
+            end_dt = timezone.make_aware(datetime.combine(end, time.max))
+            qs = qs.filter(start_time__lte=end_dt)
+    else:
+        qs = qs.filter(start_time__gte=timezone.now())
+
+    return qs
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import path
 from ninja import NinjaAPI
+from ninja_jwt.authentication import JWTAuth
 from api.views import router as api_router
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -8,7 +9,7 @@ from rest_framework_simplejwt.views import (
 )
 
 
-api = NinjaAPI(auth=None)
+api = NinjaAPI(auth=JWTAuth())
 api.add_router("/v1/", api_router)
 
 

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -1,0 +1,49 @@
+from datetime import timedelta
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+from model_bakery import baker
+
+from events.models import Source, Event
+
+
+class EventAPITests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.password = "strong-pass"
+        self.user = baker.make(User, username="apiuser")
+        self.user.set_password(self.password)
+        self.user.save()
+        self.client = APIClient()
+
+    def authenticate(self):
+        resp = self.client.post(
+            "/api/token/", {"username": self.user.username, "password": self.password}, format="json"
+        )
+        self.assertEqual(resp.status_code, 200)
+        token = resp.data["access"]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    def test_events_requires_auth(self):
+        resp = self.client.get("/api/v1/events")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_event_date_filtering(self):
+        self.authenticate()
+        source = baker.make(Source)
+        now = timezone.now()
+        past_event = baker.make(Event, source=source, start_time=now - timedelta(days=1))
+        future_event = baker.make(Event, source=source, start_time=now + timedelta(days=1))
+
+        resp = self.client.get("/api/v1/events")
+        ids = [ev["id"] for ev in resp.json()]
+        self.assertIn(future_event.id, ids)
+        self.assertNotIn(past_event.id, ids)
+
+        start = (now - timedelta(days=2)).date().isoformat()
+        end = (now + timedelta(days=2)).date().isoformat()
+        resp = self.client.get("/api/v1/events", {"start": start, "end": end})
+        ids = [ev["id"] for ev in resp.json()]
+        self.assertIn(future_event.id, ids)
+        self.assertIn(past_event.id, ids)


### PR DESCRIPTION
## Summary
- enforce JWT authentication on all API routes
- filter events by date, defaulting to upcoming events only
- add tests for API auth and date filtering

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6892450b26d48333a11ed9135c75d837