### PR TITLE
Enable CORS for local frontend

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -13,6 +13,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'rest_framework_simplejwt',
     'ninja',
@@ -22,6 +23,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -96,3 +98,7 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
 }
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:5173",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ djangorestframework
 djangorestframework-simplejwt
 django-ninja
 django-ninja-jwt
+django-cors-headers
 requests
 beautifulsoup4
 ics


### PR DESCRIPTION
## Summary
- allow the React dev server to call Django by adding django-cors-headers
- enable CORS middleware and allow http://localhost:5173

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68924912b31083339e9452c59a0e9672