### PR TITLE
Modularize settings and add AWS dev instance helper

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,4 +1,4 @@
 import os
 from django.core.asgi import get_asgi_application
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.dev')
 application = get_asgi_application()

--- a/config/settings/__init__.py
+++ b/config/settings/__init__.py
@@ -1,0 +1,1 @@
+from .dev import *

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,7 +3,6 @@ import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'change-me')
-DEBUG = True
 ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
@@ -98,7 +97,3 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
 }
-
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-]

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,0 +1,8 @@
+from .base import *
+
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:5173",
+]

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,4 +1,4 @@
 import os
 from django.core.wsgi import get_wsgi_application
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.dev')
 application = get_wsgi_application()

--- a/infra/aws_dev_instance.py
+++ b/infra/aws_dev_instance.py
@@ -1,0 +1,29 @@
+"""Utilities for creating a development EC2 instance."""
+
+import os
+
+import boto3
+
+
+def create_dev_instance():
+    """Create an EC2 instance for development using environment configuration."""
+    ec2 = boto3.resource("ec2", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+    instances = ec2.create_instances(
+        ImageId=os.environ["DEV_AMI_ID"],
+        MinCount=1,
+        MaxCount=1,
+        InstanceType="t3.micro",
+        KeyName=os.environ["DEV_KEY_NAME"],
+        SecurityGroupIds=[os.environ["DEV_SECURITY_GROUP"]],
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [{"Key": "Name", "Value": "superschedules-dev"}],
+            }
+        ],
+    )
+    print("Created instance:", instances[0].id)
+
+
+if __name__ == "__main__":
+    create_dev_instance()

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,6 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.dev')
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary
 responses
 model-bakery
 django-dynamic-fixture
+boto3


### PR DESCRIPTION
## Summary
- split Django settings into base and dev modules
- default manage/asgi/wsgi to dev settings
- add boto3-based script to provision dev EC2 instance
- include boto3 dependency

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68925d008168833384bf7eb69484a862