### PR TITLE
feat: version login token endpoints

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -15,8 +15,8 @@ api.add_router("/v1/", api_router)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("api/v1/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/v1/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/", api.urls),
 ]
 

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -19,7 +19,7 @@ class EventAPITests(TestCase):
 
     def authenticate(self):
         resp = self.client.post(
-            "/api/token/", {"username": self.user.username, "password": self.password}, format="json"
+            "/api/v1/token/", {"username": self.user.username, "password": self.password}, format="json"
         )
         self.assertEqual(resp.status_code, 200)
         token = resp.data["access"]

--- a/events/tests/test_auth.py
+++ b/events/tests/test_auth.py
@@ -14,13 +14,13 @@ class AuthTests(TestCase):
         user.save()
 
         client = APIClient()
-        resp = client.post('/api/token/', {'username': user.username, 'password': password}, format='json')
+        resp = client.post('/api/v1/token/', {'username': user.username, 'password': password}, format='json')
         assert resp.status_code == 200
         assert 'access' in resp.data
         assert 'refresh' in resp.data
 
         refresh = resp.data['refresh']
-        resp = client.post('/api/token/refresh/', {'refresh': refresh}, format='json')
+        resp = client.post('/api/v1/token/refresh/', {'refresh': refresh}, format='json')
         assert resp.status_code == 200
         assert 'access' in resp.data
 

--- a/events/tests/test_user_create.py
+++ b/events/tests/test_user_create.py
@@ -22,7 +22,7 @@ class UserCreationTests(TestCase):
         self.assertFalse(user.is_active)
 
         login_resp = client.post(
-            "/api/token/",
+            "/api/v1/token/",
             {"username": payload["email"], "password": payload["password"]},
             format="json",
         )


### PR DESCRIPTION
## Summary
- add v1 prefix to token and refresh endpoints for login
- update tests to new auth URL paths

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689289baa3a48333b7547212e760c0a2