### PR TITLE
Enable calendar month navigation

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from ninja import NinjaAPI
 from ninja_jwt.authentication import JWTAuth
 from api.views import router as api_router
@@ -14,6 +14,7 @@ api.add_router("/v1/", api_router)
 
 
 urlpatterns = [
+    path("", include("events.urls")),
     path("admin/", admin.site.urls),
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),

--- a/events/static/events/calendar.js
+++ b/events/static/events/calendar.js
@@ -1,0 +1,39 @@
+let current = new Date();
+current.setDate(1);
+
+const monthEl = document.getElementById('current-month');
+const calendarEl = document.getElementById('calendar');
+
+function renderCalendar() {
+    monthEl.textContent = current.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+    calendarEl.innerHTML = '';
+
+    const grid = document.createElement('div');
+    grid.className = 'grid';
+
+    const firstDay = current.getDay();
+    for (let i = 0; i < firstDay; i++) {
+        grid.appendChild(document.createElement('div'));
+    }
+
+    const daysInMonth = new Date(current.getFullYear(), current.getMonth() + 1, 0).getDate();
+    for (let d = 1; d <= daysInMonth; d++) {
+        const cell = document.createElement('div');
+        cell.textContent = d;
+        grid.appendChild(cell);
+    }
+
+    calendarEl.appendChild(grid);
+}
+
+document.getElementById('prev-month').addEventListener('click', () => {
+    current.setMonth(current.getMonth() - 1);
+    renderCalendar();
+});
+
+document.getElementById('next-month').addEventListener('click', () => {
+    current.setMonth(current.getMonth() + 1);
+    renderCalendar();
+});
+
+renderCalendar();

--- a/events/templates/events/calendar.html
+++ b/events/templates/events/calendar.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Calendar</title>
+    <style>
+        #calendar .grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+        #calendar .grid div { border: 1px solid #ccc; padding: 8px; min-height: 40px; }
+    </style>
+</head>
+<body>
+    <div>
+        <button id="prev-month">&lt;</button>
+        <span id="current-month"></span>
+        <button id="next-month">&gt;</button>
+    </div>
+    <div id="calendar"></div>
+    <script src="{% static 'events/calendar.js' %}"></script>
+</body>
+</html>

--- a/events/tests/test_calendar_view.py
+++ b/events/tests/test_calendar_view.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class CalendarViewTests(TestCase):
+    def test_calendar_page_renders(self):
+        response = self.client.get(reverse("calendar"))
+        self.assertEqual(response.status_code, 200)

--- a/events/urls.py
+++ b/events/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import calendar_view
+
+urlpatterns = [
+    path("", calendar_view, name="calendar"),
+]

--- a/events/views.py
+++ b/events/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def calendar_view(request):
+    return render(request, "events/calendar.html")


### PR DESCRIPTION
## Summary
- Serve a simple calendar page
- Allow switching months in calendar via frontend controls
- Cover calendar endpoint with a basic test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68928a1ec7e08333b0bc915436e9c8d7