### PR TITLE
Expose user creation endpoint without JWT auth

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -9,8 +9,11 @@ from rest_framework_simplejwt.views import (
 )
 
 
-api = NinjaAPI(auth=JWTAuth())
-api.add_router("/v1/", api_router)
+# Instantiate the API without default authentication so that
+# non-authenticated endpoints can be explicitly declared.
+api = NinjaAPI()
+# Apply JWT authentication to all routes under the "/v1" prefix.
+api.add_router("/v1/", api_router, auth=JWTAuth())
 
 
 urlpatterns = [


### PR DESCRIPTION
## Summary
- Move JWT auth from the root `NinjaAPI` to the versioned router so unauthenticated endpoints can be declared
- `create_user` endpoint remains public while other API routes stay protected

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689299502da48333b4234ed44fd230d2