### PR TITLE
Add ServiceToken admin and integrate Grappelli

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,7 @@ DEBUG = True
 ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
+    'grappelli',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from ninja import NinjaAPI
 from ninja_jwt.authentication import JWTAuth
 from api.views import router as api_router
@@ -14,6 +14,7 @@ api.add_router("/v1/", api_router, auth=JWTAuth())
 
 
 urlpatterns = [
+    path("grappelli/", include("grappelli.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/v1/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),

--- a/events/admin.py
+++ b/events/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin, messages
 from django.utils import timezone
 import re
-from .models import Source, Event
+from .models import Source, Event, ServiceToken
 from .scraper import scrape_events_for_query, scrape_events_for_domain
 
 @admin.register(Source)
@@ -40,3 +40,9 @@ class SourceAdmin(admin.ModelAdmin):
 class EventAdmin(admin.ModelAdmin):
     list_display = ('title', 'source', 'start_time', 'location')
     search_fields = ('title', 'description')
+
+
+@admin.register(ServiceToken)
+class ServiceTokenAdmin(admin.ModelAdmin):
+    list_display = ("name", "token", "created_at")
+    readonly_fields = ("token", "created_at")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary
 responses
 model-bakery
 django-dynamic-fixture
+django-grappelli


### PR DESCRIPTION
## Summary
- register `ServiceToken` model in admin with read-only token display
- install and configure Django Grappelli for improved admin UI

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6893b4fca5ac8333ad7a2e27cf971bdd