### PR TITLE
Implement password reset email flow

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -104,3 +104,17 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://localhost:5174",
 ]
+
+# Email configuration for password reset
+EMAIL_BACKEND = os.environ.get(
+    "EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "no-reply@example.com")
+
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
+PASSWORD_RESET_TIMEOUT = int(os.environ.get("PASSWORD_RESET_TIMEOUT", 3600))

--- a/events/tests/test_password_reset.py
+++ b/events/tests/test_password_reset.py
@@ -1,0 +1,30 @@
+from django.test import TestCase, override_settings
+from django.contrib.auth import get_user_model
+from django.core import mail
+from rest_framework.test import APIClient
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class PasswordResetTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='resetuser',
+            email='reset@example.com',
+            password='initial-pass',
+        )
+        self.client = APIClient()
+
+    def test_request_and_confirm_password_reset(self):
+        resp = self.client.post('/api/v1/reset/', {'email': self.user.email}, format='json')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['message'], 'Check your email for a password reset link.')
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        token = body.split('token=')[1].strip()
+        new_pass = 'new-strong-pass'
+        resp = self.client.post('/api/v1/reset/confirm/', {'token': token, 'password': new_pass}, format='json')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['message'], 'Password has been reset.')
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(new_pass))


### PR DESCRIPTION
## Summary
- add configurable Gmail SMTP settings for outgoing mail and password reset support
- expose password reset and confirmation endpoints that issue and validate signed tokens
- cover password reset flow with tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6893d6f89f948333aee9e4dcdae3520d