### PR TITLE
Update event and reset password auth behavior

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -129,7 +129,7 @@ def confirm_password_reset(request, payload: PasswordResetConfirmSchema):
     return {"message": "Password has been reset."}
 
 
-@router.get("/ping")
+@router.get("/ping", auth=JWTAuth())
 def ping(request):
     return {"message": f"Hello, {request.user.username}!"}
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,16 +1,16 @@
 from django.contrib import admin
 from django.urls import path, include
 from ninja import NinjaAPI
-from ninja_jwt.authentication import JWTAuth
 from api.views import router as api_router
 from rest_framework_simplejwt.views import (TokenObtainPairView, TokenRefreshView)
 
 
-# Instantiate the API without default authentication so that
-# non-authenticated endpoints can be explicitly declared.
+# Instantiate the API without a global authentication requirement.
+# Individual routes will specify authentication as needed, allowing
+# certain endpoints such as password reset to be accessed without
+# credentials.
 api = NinjaAPI()
-# Apply JWT authentication to all routes under the "/v1" prefix.
-api.add_router("/v1/", api_router, auth=JWTAuth())
+api.add_router("/v1/", api_router)
 
 
 urlpatterns = [


### PR DESCRIPTION
## Summary
- expose API router without global JWT requirement so password reset endpoints are public
- explicitly require JWT for ping endpoint

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6893da14367483338e5a200c1c08e15a